### PR TITLE
Improve error message when wrongly nesting GpuLayout types

### DIFF
--- a/shame/src/common/proc_macro_reexports.rs
+++ b/shame/src/common/proc_macro_reexports.rs
@@ -39,7 +39,7 @@ pub use crate::frontend::rust_types::type_traits::NoAtomics;
 pub use crate::frontend::rust_types::type_traits::NoBools;
 pub use crate::frontend::rust_types::type_traits::NoHandles;
 pub use crate::frontend::rust_types::type_traits::VertexAttribute;
-pub use crate::frontend::rust_types::type_traits::FromAny;
+pub use crate::frontend::rust_types::type_traits::GpuLayoutField;
 pub use crate::frontend::rust_types::AsAny;
 pub use crate::frontend::rust_types::GpuType;
 #[allow(missing_docs)]

--- a/shame/src/common/proc_macro_reexports.rs
+++ b/shame/src/common/proc_macro_reexports.rs
@@ -39,6 +39,7 @@ pub use crate::frontend::rust_types::type_traits::NoAtomics;
 pub use crate::frontend::rust_types::type_traits::NoBools;
 pub use crate::frontend::rust_types::type_traits::NoHandles;
 pub use crate::frontend::rust_types::type_traits::VertexAttribute;
+pub use crate::frontend::rust_types::type_traits::FromAny;
 pub use crate::frontend::rust_types::AsAny;
 pub use crate::frontend::rust_types::GpuType;
 #[allow(missing_docs)]

--- a/shame/src/frontend/rust_types/type_traits.rs
+++ b/shame/src/frontend/rust_types/type_traits.rs
@@ -230,13 +230,13 @@ pub trait VertexAttribute: GpuLayout + FromAnys {
 /// struct B { a: shame::Struct<A> }
 /// which the error message points out.
 #[diagnostic::on_unimplemented(
-    message = "Try using shame::Struct<{Self}> instead. If that doesn't work {Self} can not be used as the field of a type deriving shame::GpuLayout."
+    message = "{Self} is not a valid `shame::GpuLayout` field type. These include `shame::GpuType`s and `shame::packed::PackedVec`. If {Self} is a `shame::GpuLayout` struct, it can be used as a field by wrapping it in `shame::Struct<{Self}>`."
 )]
-pub trait FromAny {
+pub trait GpuLayoutField {
     /// Constructs Self from Any
     fn from_any(any: Any) -> Self;
 }
 
-impl<T: From<Any>> FromAny for T {
+impl<T: From<Any>> GpuLayoutField for T {
     fn from_any(any: Any) -> Self { T::from(any) }
 }

--- a/shame/src/frontend/rust_types/type_traits.rs
+++ b/shame/src/frontend/rust_types/type_traits.rs
@@ -217,3 +217,26 @@ pub trait VertexAttribute: GpuLayout + FromAnys {
     #[doc(hidden)] // runtime api
     fn vertex_attrib_format() -> VertexAttribFormat;
 }
+
+/// Trait that the fields of a derived `GpuLayout` type must implement.
+/// This is used for showing a more helpful error message when trying to use
+/// #[derive(GpuLayout)]
+/// struct A { ... }
+/// in
+/// #[derive(GpuLayout)]
+/// struct B { a: A }
+/// directly. This should instead be
+/// #[derive(GpuLayout)]
+/// struct B { a: shame::Struct<A> }
+/// which the error message points out.
+#[diagnostic::on_unimplemented(
+    message = "Try using shame::Struct<{Self}> instead. If that doesn't work {Self} can not be used as the field of a type deriving shame::GpuLayout."
+)]
+pub trait FromAny {
+    /// Constructs Self from Any
+    fn from_any(any: Any) -> Self;
+}
+
+impl<T: From<Any>> FromAny for T {
+    fn from_any(any: Any) -> Self { T::from(any) }
+}

--- a/shame_derive/src/derive_layout.rs
+++ b/shame_derive/src/derive_layout.rs
@@ -271,7 +271,7 @@ pub fn impl_for_struct(
                         };
 
                         Self {
-                            #(#field_ident: <#field_type as From<#re::Any>>::from(#field_ident)),*
+                            #(#field_ident: <#field_type as #re::FromAny>::from_any(#field_ident)),*
                         }
                     }
                 }

--- a/shame_derive/src/derive_layout.rs
+++ b/shame_derive/src/derive_layout.rs
@@ -271,7 +271,7 @@ pub fn impl_for_struct(
                         };
 
                         Self {
-                            #(#field_ident: <#field_type as #re::FromAny>::from_any(#field_ident)),*
+                            #(#field_ident: <#field_type as #re::GpuLayoutField>::from_any(#field_ident)),*
                         }
                     }
                 }


### PR DESCRIPTION
Improves the error message of
```rust
#[derive(sm::GpuLayout)]
struct A { a: f32x1 }
#[derive(sm::GpuLayout)]
struct B { a: A }
``` 
which should be
```rust
#[derive(sm::GpuLayout)]
struct B { a: sm::Struct<A> }
```
from
![image](https://github.com/user-attachments/assets/4fd53ce1-46f0-4052-969b-1bda9848876b)
to
![image](https://github.com/user-attachments/assets/a236e61d-6d0c-4c7c-86b3-dc8a62e17144)

### Further thoughts
- Could change the name of `FromAny` to something describing the error. 
- Not sure how to implement a test for this.