### PR TITLE
Added WGPU based test utilities

### DIFF
--- a/shame/Cargo.toml
+++ b/shame/Cargo.toml
@@ -27,3 +27,7 @@ shame_derive = { path = "../shame_derive/" }
 static_assertions = "1.1.0"
 pretty_assertions = "1.4.1"
 glam = "0.29.0"
+shame_wgpu = { path = "../examples/shame_wgpu" }
+bytemuck = { version = "1.19", features = ["derive"] }
+wgpu = "25.0.2"
+pollster = "0.4"

--- a/shame/tests/common/buffer_mapping.rs
+++ b/shame/tests/common/buffer_mapping.rs
@@ -1,0 +1,75 @@
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum MappingStatus {
+    NotMappedYet,
+    Error(wgpu::BufferAsyncError),
+}
+
+use std::sync::{Arc, Mutex};
+
+use bytemuck::AnyBitPattern;
+
+/// convenient buffer mapping guard for writing tests
+struct BufferMapping<'a> {
+    slice: wgpu::BufferSlice<'a>,
+    status: Arc<Mutex<Result<(), MappingStatus>>>,
+}
+
+impl<'a> BufferMapping<'a> {
+    pub fn announce_read(slice: wgpu::BufferSlice<'a>) -> Self {
+        let mode = wgpu::MapMode::Read;
+
+        let status = Arc::new(Mutex::new(Err(MappingStatus::NotMappedYet)));
+
+        slice.map_async(mode, {
+            let status = status.clone();
+            move |result| {
+                let mut status = status.lock().unwrap();
+                *status = result.map_err(MappingStatus::Error)
+            }
+        });
+
+        Self { slice, status }
+    }
+
+    pub fn block_on_read<T: AnyBitPattern>(self, gpu: &wgpu::Device) -> Result<Vec<T>, wgpu::BufferAsyncError> {
+        // since gpu.poll is a noop when targeting WebGPU, it is not guaranteed
+        // that calling gpu.poll accomplishes anything, so if the buffer
+        // was not mapped, we effectively spin here until it has been done.
+        loop {
+            match self.try_read() {
+                Err(MappingStatus::NotMappedYet) => match gpu.poll(wgpu::PollType::Poll) {
+                    Ok(wgpu::PollStatus::Poll | wgpu::PollStatus::QueueEmpty) => std::hint::spin_loop(),
+                    x => unreachable!("PollType::Poll returns PollType::Wait-related value: {:?}", x),
+                },
+                Err(MappingStatus::Error(e)) => break Err(e),
+                Ok(t) => break Ok(t),
+            };
+        }
+    }
+
+    pub fn try_read<T: AnyBitPattern>(&self) -> Result<Vec<T>, MappingStatus> {
+        self.status.lock().unwrap().clone()?;
+        let slice_guard = self.slice.get_mapped_range();
+        Ok(bytemuck::cast_slice(&slice_guard).into())
+    }
+
+    #[allow(unused)]
+    pub fn try_read_once<T: AnyBitPattern>(self) -> Result<Vec<T>, MappingStatus> {
+        self.try_read()
+        // implicit drop(self)
+    }
+}
+
+impl Drop for BufferMapping<'_> {
+    fn drop(&mut self) { self.slice.buffer().unmap(); }
+}
+
+/// load the data from a buffer with appropriate usage flags and
+/// reinterpret it as a slice of `T`
+pub fn download_buffer_from_gpu<T: AnyBitPattern>(
+    gpu: &wgpu::Device,
+    slice: wgpu::BufferSlice,
+) -> Result<Vec<T>, wgpu::BufferAsyncError> {
+    let mapping = BufferMapping::announce_read(slice);
+    mapping.block_on_read(&gpu)
+}

--- a/shame/tests/common/gpu.rs
+++ b/shame/tests/common/gpu.rs
@@ -1,0 +1,41 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    RequestAdapter(#[from] wgpu::RequestAdapterError),
+    #[error(transparent)]
+    RequestDevice(#[from] wgpu::RequestDeviceError),
+}
+
+#[allow(unused)]
+pub struct Setup {
+    instance: wgpu::Instance,
+    adapter: wgpu::Adapter,
+    pub gpu: shame_wgpu::Gpu,
+}
+
+impl Setup {
+    pub fn new(features: wgpu::Features, limits: wgpu::Limits) -> Result<Setup, Error> {
+        let instance = wgpu::Instance::default();
+        let adapter = instance.request_adapter(&Default::default());
+        let adapter = pollster::block_on(adapter)?;
+
+        let device_queue = adapter.request_device(&wgpu::DeviceDescriptor {
+            label: None,
+            required_features: features,
+            required_limits: limits,
+            memory_hints: wgpu::MemoryHints::Performance,
+            trace: wgpu::Trace::Off,
+        });
+        let (device, queue) = pollster::block_on(device_queue)?;
+
+        let setup = Setup {
+            instance,
+            adapter,
+            gpu: shame_wgpu::Gpu::new(device, queue, None),
+        };
+
+        Ok(setup)
+    }
+}

--- a/shame/tests/common/mod.rs
+++ b/shame/tests/common/mod.rs
@@ -1,0 +1,232 @@
+pub mod buffer_mapping;
+pub mod gpu;
+pub mod test_image;
+pub mod wgpu_error_scope;
+use shame_wgpu as sm;
+use sm::prelude::*;
+use wgpu::util::{DeviceExt};
+use pollster::block_on;
+
+use crate::common::{
+    buffer_mapping::download_buffer_from_gpu,
+    test_image::{TestImage2D, TestImageFormat},
+    wgpu_error_scope::WgpuErrorScope,
+};
+
+/// calls `gpu::Setup::new` with reasonable default parameters.
+/// If your test requires some specific capabilities, you can call `gpu::Setup`
+/// yourself and skip the test based on the `Err` variant instead.
+pub fn basic_test_setup() -> Result<gpu::Setup, gpu::Error> {
+    let features = wgpu::Features::PUSH_CONSTANTS;
+
+    let limits = wgpu::Limits {
+        max_push_constant_size: 4,
+        ..Default::default()
+    };
+
+    gpu::Setup::new(features, limits)
+}
+
+/// initialize a `[T; N]` array on the gpu with the given function `F`.
+/// This is intended for tests, as it will compile a compute pipeline from `F`
+/// only for this one call and then discard it.
+///
+/// * `dispatch_wgs`: the dimensions of the grid of workgroups that are being dispatched
+/// * `wg_dims`: the dimensions of the thread-grid that makes up each individual workgroup
+#[track_caller]
+pub fn init_array_via_gpu_compute<const N: usize, const D: usize, T, F>(
+    gpu: sm::Gpu,
+    dispatch_wgs: [u32; D],
+    wg_dims: [u32; D],
+    f: F,
+) -> [T; N]
+where
+    T: sm::ScalarTypeNumber + std::fmt::Debug + bytemuck::Pod,
+    sm::vec<T, x1>: sm::NoBools,
+    [u32; D]: sm::GridSize,
+    F: FnOnce(
+        sm::DispatchContext<<[u32; D] as sm::GridSize>::Dim>,
+        sm::BufferRef<sm::Array<sm::vec<T, x1>, sm::Size<N>>>,
+    ),
+{
+    let caller = sm::__private::CallInfo::caller();
+
+    let catch = WgpuErrorScope::new(&gpu);
+
+    let pipeline: wgpu::ComputePipeline = {
+        let mut enc = gpu.create_pipeline_encoder(Default::default()).unwrap();
+        let mut pipe = enc.new_compute_pipeline(wg_dims);
+        println!("test @ {caller}");
+        let buffer = pipe.bind_groups.next().next();
+        f(pipe, buffer);
+        enc.finish().unwrap()
+    };
+
+    block_on(catch.next()).unwrap();
+
+    let storage_buffer_cpu = [T::zeroed(); N];
+    let bytes = bytemuck::cast_slice(&storage_buffer_cpu);
+
+    let storage_buffer = gpu.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: None,
+        contents: bytes,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+    });
+
+    block_on(catch.next()).unwrap();
+
+    let staging_buffer = gpu.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: bytes.len() as _,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    block_on(catch.next()).unwrap();
+
+    let bind_group_layout = pipeline.get_bind_group_layout(0);
+    let bind_group = gpu.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &bind_group_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: storage_buffer.as_entire_binding(),
+        }],
+    });
+
+    let mut encoder = gpu.create_command_encoder(&Default::default());
+    {
+        let mut pass = encoder.begin_compute_pass(&Default::default());
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        use sm::GridSize as _;
+        let [x, y, z] = dispatch_wgs.as_3d();
+        pass.dispatch_workgroups(x, y, z);
+    }
+
+    encoder.copy_buffer_to_buffer(&storage_buffer, 0, &staging_buffer, 0, bytes.len() as _);
+
+    gpu.queue().submit([encoder.finish()]);
+    gpu.poll(wgpu::PollType::Wait).unwrap();
+    let result = download_buffer_from_gpu(&gpu, staging_buffer.slice(..)).unwrap();
+
+    block_on(catch.finish()).unwrap();
+    result.try_into().unwrap() // Vec<T> -> [T; N]
+}
+
+pub trait VertexIndexing {
+    const SM: sm::Indexing;
+    fn indexing(&self) -> IndexRepr;
+}
+
+pub enum IndexRepr<'a> {
+    Range(std::ops::Range<u32>),
+    Buffer(&'a [u8], usize),
+}
+
+impl VertexIndexing for std::ops::Range<u32> {
+    const SM: sm::Indexing = sm::Indexing::Incremental;
+    fn indexing(&self) -> IndexRepr { IndexRepr::Range(self.clone()) }
+}
+
+impl VertexIndexing for &[u32] {
+    const SM: sm::Indexing = sm::Indexing::BufferU32;
+    fn indexing(&self) -> IndexRepr { IndexRepr::Buffer(bytemuck::cast_slice(self), self.len()) }
+}
+
+impl VertexIndexing for &[u16] {
+    const SM: sm::Indexing = sm::Indexing::BufferU16;
+    fn indexing(&self) -> IndexRepr { IndexRepr::Buffer(bytemuck::cast_slice(self), self.len()) }
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> TestImage2D<Fmt, W, H> {
+    #[track_caller]
+    pub fn render_on_gpu<Idx, F>(gpu: &sm::Gpu, indexing: Idx, instances: std::ops::Range<u32>, f: F) -> Self
+    where
+        Idx: VertexIndexing,
+        Fmt: TestImageFormat + sm::ColorTargetFormat,
+        F: FnOnce(sm::DrawContext),
+    {
+        let caller = sm::__private::CallInfo::caller();
+
+        let catch = WgpuErrorScope::new(&gpu);
+
+        let pipeline: wgpu::RenderPipeline = {
+            let mut enc = gpu.create_pipeline_encoder(Default::default()).unwrap();
+            let draw = enc.new_render_pipeline(Idx::SM);
+            println!("test @ {caller}");
+            f(draw);
+            enc.finish().unwrap()
+        };
+
+        block_on(catch.next()).unwrap();
+
+        let test_image: TestImage2D<Fmt, W, H> = Default::default();
+
+        let texture = test_image.upload_to_gpu(&gpu, &gpu.queue());
+        let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
+            label: Some("test view"),
+            format: Some(sm::conversion::texture_format(&Fmt::id(), None).unwrap()),
+            dimension: Some(wgpu::TextureViewDimension::D2),
+            usage: Some(wgpu::TextureUsages::RENDER_ATTACHMENT),
+            aspect: wgpu::TextureAspect::All,
+            base_mip_level: 0,
+            mip_level_count: None,
+            base_array_layer: 0,
+            array_layer_count: None,
+        });
+
+        let index_buffer = match indexing.indexing() {
+            IndexRepr::Range(_) => None,
+            IndexRepr::Buffer(data, _len) => Some((
+                gpu.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("index buffer"),
+                    contents: data,
+                    usage: wgpu::BufferUsages::INDEX,
+                }),
+                match Idx::SM {
+                    shame::Indexing::Incremental => unreachable!(),
+                    shame::Indexing::BufferU8 => panic!("unsupported index format"),
+                    shame::Indexing::BufferU16 => wgpu::IndexFormat::Uint16,
+                    shame::Indexing::BufferU32 => wgpu::IndexFormat::Uint32,
+                },
+            )),
+        };
+
+        let mut encoder = gpu.create_command_encoder(&Default::default());
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("test"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &texture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                ..Default::default()
+            });
+            pass.set_pipeline(&pipeline);
+            pass.insert_debug_marker("test");
+            if let Some((buffer, fmt)) = index_buffer {
+                pass.set_index_buffer(buffer.slice(..), fmt);
+            }
+
+            match indexing.indexing() {
+                IndexRepr::Range(range) => pass.draw(range, instances),
+                IndexRepr::Buffer(_, len) => pass.draw_indexed(0..len as u32, 0, instances),
+            }
+        }
+
+        gpu.queue().submit([encoder.finish()]);
+
+        block_on(catch.next()).unwrap();
+
+        let _ = gpu.poll(wgpu::PollType::Wait);
+
+        let test_image = TestImage2D::download_from_gpu(&gpu, &texture);
+
+        block_on(catch.err_or(test_image)).unwrap()
+    }
+}

--- a/shame/tests/common/test_image.rs
+++ b/shame/tests/common/test_image.rs
@@ -1,0 +1,291 @@
+use std::fmt::Display;
+
+use shame_wgpu as sm;
+use wgpu::util::DeviceExt;
+
+use crate::common::buffer_mapping::download_buffer_from_gpu;
+
+pub trait TestImageFormat: sm::TextureFormat {
+    type Texel: Copy + Default + AsRef<[u8]> + AsMut<[u8]> + PartialEq + Eq + bytemuck::NoUninit;
+    const NUM_CHANNELS: usize;
+}
+
+#[rustfmt::skip] impl TestImageFormat for sm::tf::R8Uint         { type Texel = [u8; 1]; const NUM_CHANNELS: usize = 1; }
+#[rustfmt::skip] impl TestImageFormat for sm::tf::Rg8Uint        { type Texel = [u8; 2]; const NUM_CHANNELS: usize = 2; }
+#[rustfmt::skip] impl TestImageFormat for sm::tf::Rgba8Uint      { type Texel = [u8; 4]; const NUM_CHANNELS: usize = 4; }
+#[rustfmt::skip] impl TestImageFormat for sm::tf::Rgba8Unorm     { type Texel = [u8; 4]; const NUM_CHANNELS: usize = 4; }
+#[rustfmt::skip] impl TestImageFormat for sm::tf::Rgba8UnormSrgb { type Texel = [u8; 4]; const NUM_CHANNELS: usize = 4; }
+#[rustfmt::skip] impl TestImageFormat for sm::tf::Rg8Unorm       { type Texel = [u8; 2]; const NUM_CHANNELS: usize = 2; }
+#[rustfmt::skip] impl TestImageFormat for sm::tf::R8Unorm        { type Texel = [u8; 1]; const NUM_CHANNELS: usize = 1; }
+
+/// a 2D image that can be created from - and displayed as - a monospaced 2D grid of
+/// hex/unicode glyphs, arranged in columns for each color channel
+/// ```
+/// R                G
+/// ░░░░░░░░FD░░░░░░ ░░░░░░░░CC░░░░░░
+/// ░░░░░░░░FEFE░░░░ ░░░░░░░░FEFE░░░░
+/// ░░░░░░░░▓▓▓▓▓▓░░ ░░░░░░░░▓▓▓▓▓▓░░
+/// ░░░░░░░░▓▓▓▓▓▓▓▓ ░░░░░░░░▓▓▓▓▓▓▓▓
+/// ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+/// ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+/// ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+/// ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+/// ```
+/// each texel is represented by 2 characters.
+/// special characters for improved readability are:
+/// ```
+/// ▓▓ = 0xFF
+/// ▒▒ = 0x80
+/// ░░ = 0x00
+/// ```
+/// all other values are displayed as their hex representation, e.g. the
+/// top most texel of the shown triangle has color `{ red: 0xFD, green: 0xCC }`
+#[derive(Clone, Copy, Eq)]
+pub struct TestImage2D<Fmt: TestImageFormat, const W: usize, const H: usize> {
+    data: [[Fmt::Texel; W]; H],
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> PartialEq for TestImage2D<Fmt, W, H> {
+    fn eq(&self, other: &Self) -> bool { self.data == other.data }
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> std::fmt::Debug for TestImage2D<Fmt, W, H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self) }
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> Default for TestImage2D<Fmt, W, H> {
+    fn default() -> Self {
+        TestImage2D {
+            data: [[Fmt::Texel::default(); W]; H],
+        }
+    }
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> Display for TestImage2D<Fmt, W, H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f)?;
+        for channel_i in 0..Fmt::NUM_CHANNELS {
+            f.write_str(match channel_i {
+                0 => "R",
+                1 => "G",
+                2 => "B",
+                3 => "A",
+                _ => "?",
+            })?;
+            write!(f, " ")?;
+            for _ in 1..W {
+                write!(f, "  ")?;
+            }
+            write!(f, " ")?;
+        }
+        writeln!(f)?;
+        for row in &self.data {
+            for channel_i in 0..Fmt::NUM_CHANNELS {
+                for texel in row {
+                    match texel.as_ref().get(channel_i) {
+                        Some(u8) => match u8 {
+                            0xFF => write!(f, "▓▓")?,
+                            0x80 => write!(f, "▒▒")?,
+                            0x00 => write!(f, "░░")?,
+                            _ => write!(f, "{:02x?}", u8)?,
+                        },
+                        None => write!(f, "??")?,
+                    }
+                }
+                write!(f, " ")?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum TestImageError {
+    InvalidString,
+    InvalidChannelCount { expected: usize, got: usize },
+}
+
+impl Display for TestImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TestImageError::InvalidString => write!(f, "invalid string"),
+            TestImageError::InvalidChannelCount { expected, got } => {
+                write!(f, "invalid channel count: expected {expected}, got {got}")
+            }
+        }
+    }
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> TestImage2D<Fmt, W, H> {
+    pub fn download_from_gpu(gpu: &sm::Gpu, texture: &wgpu::Texture) -> Self {
+        // round up to next 256 multiple because of the `copy_texture_to_buffer` alignment requirement
+        let bytes_per_row = size_of::<[Fmt::Texel; W]>().next_multiple_of(256) as u64;
+        let byte_size = bytes_per_row * H as u64;
+
+        let texture_size = wgpu::Extent3d {
+            width: W as u32,
+            height: H as u32,
+            depth_or_array_layers: 1,
+        };
+
+        let staging_buffer = gpu.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("TestImage2D download staging buffer"),
+            size: byte_size,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut enc = gpu.create_command_encoder(&Default::default());
+
+        enc.copy_texture_to_buffer(
+            texture.as_image_copy(),
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bytes_per_row as u32),
+                    rows_per_image: Some(H as u32),
+                },
+            },
+            texture_size,
+        );
+
+        gpu.queue().submit([enc.finish()]);
+        gpu.poll(wgpu::PollType::Wait).unwrap();
+
+        let downloaded = download_buffer_from_gpu(&gpu, staging_buffer.slice(..)).unwrap();
+
+        Self {
+            data: {
+                std::array::from_fn(|y| {
+                    std::array::from_fn(|x| {
+                        let mut texel = Fmt::Texel::default();
+                        let size_of_texel = size_of::<Fmt::Texel>();
+                        for (i, chan) in texel.as_mut().iter_mut().enumerate() {
+                            *chan = downloaded[y * bytes_per_row as usize + x * size_of_texel + i]
+                        }
+                        texel
+                    })
+                })
+            },
+        }
+    }
+
+    pub fn upload_to_gpu(&self, gpu: &wgpu::Device, q: &wgpu::Queue) -> wgpu::Texture {
+        let texture_size = wgpu::Extent3d {
+            width: W as u32,
+            height: H as u32,
+            depth_or_array_layers: 1,
+        };
+
+        let texture = gpu.create_texture_with_data(
+            q,
+            &wgpu::TextureDescriptor {
+                size: texture_size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: shame_wgpu::conversion::texture_format(&Fmt::id(), None).unwrap(),
+                usage: wgpu::TextureUsages::TEXTURE_BINDING |
+                    wgpu::TextureUsages::RENDER_ATTACHMENT |
+                    wgpu::TextureUsages::COPY_DST |
+                    wgpu::TextureUsages::COPY_SRC,
+                label: Some("test image"),
+                view_formats: &[],
+            },
+            wgpu::util::TextureDataOrder::LayerMajor,
+            bytemuck::cast_slice(self.data.as_flattened()),
+        );
+
+        texture
+    }
+}
+
+impl<Fmt: TestImageFormat, const W: usize, const H: usize> TestImage2D<Fmt, W, H> {
+    pub fn try_from_str(str: &str) -> Result<Self, TestImageError> {
+        let err = || TestImageError::InvalidString;
+        let str = str.trim();
+
+        let line0 = str.lines().next().ok_or_else(err)?;
+
+        let words = line0.split_ascii_whitespace();
+        if words.clone().count() > Fmt::NUM_CHANNELS {
+            return Err(TestImageError::InvalidChannelCount {
+                expected: Fmt::NUM_CHANNELS,
+                got: words.clone().count(),
+            });
+        }
+
+        let mut channel_order = {
+            let mut order = Vec::new();
+            for word in words {
+                for (i, &ch) in ["R", "G", "B", "A"].iter().enumerate() {
+                    if word == ch {
+                        if order.contains(&i) {
+                            return Err(err());
+                        }
+                        order.push(i);
+                    }
+                }
+            }
+            order
+        };
+
+        let mut lines = str.lines();
+        match channel_order.is_empty() {
+            true => {
+                // no channel-line, start parsing content right away
+                channel_order.push(0);
+            }
+            false => {
+                // skip first line wrt content
+                lines.next();
+            }
+        }
+
+        // parse texels
+        let mut data: [[Fmt::Texel; W]; H] = std::array::from_fn(|_| std::array::from_fn(|_| Default::default()));
+        for (y, line) in lines.enumerate() {
+            for (&channel_index, word) in channel_order.iter().zip(line.split_ascii_whitespace()) {
+                let row: [u8; W] = parse_row(word).ok_or_else(err)?;
+                for x in 0..row.len() {
+                    let texel = &mut data[y][x].as_mut();
+                    texel[channel_index] = row[x];
+                }
+            }
+        }
+
+        Ok(Self { data })
+    }
+}
+
+#[allow(clippy::needless_range_loop)]
+fn parse_row<const N: usize>(word: &str) -> Option<[u8; N]> {
+    let mut arr = [0; N];
+    if word.chars().count() != N * 2 {
+        return None;
+    }
+    for i in 0..N {
+        let texel_str = {
+            let mut char_it = word
+                .char_indices()
+                .map(|(i, _)| i)
+                .chain(std::iter::once(word.len()))
+                .skip(i * 2);
+            let start = char_it.next()?;
+            char_it.next(); // every "texel" has 2 chars, skip middle boundary
+            let end = char_it.next()?;
+            &word[start..end]
+        };
+
+        arr[i] = match texel_str {
+            "░░" => 0x00,
+            "▒▒" => 0x80,
+            "▓▓" => 0xFF,
+            s if s.chars().count() == 2 => u8::from_str_radix(s, 16).ok()?,
+            _ => unreachable!("texel_str should already be 2 chars guaranteed, but it is `{texel_str}`"),
+        };
+    }
+    Some(arr)
+}

--- a/shame/tests/common/wgpu_error_scope.rs
+++ b/shame/tests/common/wgpu_error_scope.rs
@@ -1,0 +1,142 @@
+use std::{
+    cell::Cell,
+    collections::VecDeque,
+    fmt::{Debug, Display},
+};
+
+const ALL_ERROR_FILTERS: [wgpu::ErrorFilter; 3] = [
+    wgpu::ErrorFilter::Validation,
+    wgpu::ErrorFilter::OutOfMemory,
+    wgpu::ErrorFilter::Internal,
+];
+
+/// raii guard for pushing/popping of error scopes
+///
+/// one `WgpuErrorScope` creates multiple error scopes internally, one for
+/// each of [`ALL_ERROR_FILTERS`]
+pub struct WgpuErrorScope<'a> {
+    device: &'a wgpu::Device,
+    unpopped_scopes: bool,
+    location: Cell<&'static std::panic::Location<'static>>,
+}
+
+impl<'a> WgpuErrorScope<'a> {
+    #[track_caller]
+    pub fn new(device: &'a wgpu::Device) -> Self {
+        push_all_filters_error_scopes(device);
+        Self {
+            device,
+            unpopped_scopes: true,
+            location: Cell::new(std::panic::Location::caller()),
+        }
+    }
+
+    /// collect wgpu errors and return them, destroy self.
+    pub async fn finish(mut self) -> Result<(), WgpuErrors> {
+        self.unpopped_scopes = false;
+        pop_all_filters_error_scopes(self.device).await
+    }
+
+    /// collects wgpu errors and returns them as `Err` if there are any.
+    /// Otherwise returns `Ok(t)`
+    #[allow(unused)]
+    pub async fn err_or<T>(self, t: T) -> Result<T, WgpuErrors> {
+        self.finish().await?;
+        Ok(t)
+    }
+
+    pub async fn next(&self) -> Result<(), WgpuErrors> {
+        let result = pop_all_filters_error_scopes(self.device);
+        push_all_filters_error_scopes(self.device);
+        self.location.set(std::panic::Location::caller());
+        result.await // await only after the error scopes have been popped and pushed
+    }
+}
+
+fn push_all_filters_error_scopes(device: &wgpu::Device) {
+    ALL_ERROR_FILTERS.map(|filter| device.push_error_scope(filter));
+}
+
+async fn pop_all_filters_error_scopes(device: &wgpu::Device) -> Result<(), WgpuErrors> {
+    // only await after all scopes have been popped.
+    let pending_results = ALL_ERROR_FILTERS.map(|_| device.pop_error_scope());
+
+    let mut errors = None;
+    for pending_result in pending_results {
+        if let Some(err) = pending_result.await {
+            push_error(&mut errors, err)
+        }
+    }
+    match errors {
+        Some(errors) => Err(errors),
+        None => Ok(()),
+    }
+}
+
+impl Drop for WgpuErrorScope<'_> {
+    #[track_caller]
+    fn drop(&mut self) {
+        // you should call `.finish()` or other consuming functions on
+        // a `WgpuErrorScope` before you destroy it.
+        if self.unpopped_scopes {
+            if cfg!(debug_assertions) {
+                let loc = self.location.get();
+                println!(
+                    "uncaught wgpu error scope in:\n{}:{}:{}",
+                    loc.file(),
+                    loc.line(),
+                    loc.column()
+                );
+            }
+            let _ = pollster::block_on(pop_all_filters_error_scopes(self.device));
+        }
+    }
+}
+
+pub struct WgpuErrors {
+    pub first: wgpu::Error,
+    pub rest: VecDeque<wgpu::Error>,
+}
+
+impl std::error::Error for WgpuErrors {}
+
+impl Debug for WgpuErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{self}") }
+}
+
+impl Display for WgpuErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.rest.len() {
+            0 => write!(f, "{}", self.first),
+            n => {
+                writeln!(f, "{n} wgpu errors:")?;
+                writeln!(f, "{}", self.first)?;
+                for e in self.rest.iter() {
+                    writeln!(f, "{e}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl From<wgpu::Error> for WgpuErrors {
+    fn from(first: wgpu::Error) -> Self {
+        WgpuErrors {
+            first,
+            rest: Default::default(),
+        }
+    }
+}
+
+fn push_error(errors: &mut Option<WgpuErrors>, error: wgpu::Error) {
+    match errors {
+        Some(errors) => errors.rest.push_back(error),
+        None => {
+            *errors = Some(WgpuErrors {
+                first: error,
+                rest: Default::default(),
+            })
+        }
+    }
+}

--- a/shame/tests/test_run_pipeline.rs
+++ b/shame/tests/test_run_pipeline.rs
@@ -1,0 +1,54 @@
+mod common;
+use common::*;
+use crate::common::{test_image::TestImage2D};
+use shame_wgpu as sm;
+
+#[test]
+fn basic_compute_pipeline_test() {
+    let gpu = basic_test_setup().unwrap().gpu;
+
+    assert_eq!(
+        [1.0; 64],
+        init_array_via_gpu_compute(gpu, [1, 1], [8, 8], |dispatch, arr| {
+            arr.at(dispatch.workgroup.thread_id).set(1.0);
+        })
+    );
+}
+
+#[test]
+fn basic_render_pipeline_test() {
+    let gpu = basic_test_setup().unwrap().gpu;
+
+    let expected = TestImage2D::<sm::tf::Rg8Uint, 8, 8>::try_from_str(
+        "
+            R                G
+            ░░░░░░░░▓▓░░░░░░ ░░░░░░░░▒▒░░░░░░
+            ░░░░░░░░▓▓▓▓░░░░ ░░░░░░░░▒▒▒▒░░░░
+            ░░░░░░░░▓▓▓▓▓▓░░ ░░░░░░░░▒▒▒▒▒▒░░
+            ░░░░░░░░▓▓▓▓▓▓▓▓ ░░░░░░░░▒▒▒▒▒▒▒▒
+            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
+        ",
+    )
+    .unwrap();
+
+    let actual = TestImage2D::render_on_gpu(&gpu, /*indices*/ 0..3, /*instances*/ 0..1, |drawcall| {
+        let vi = drawcall.vertices.index;
+        let triangle = sm::Array::new([(0.0, 0.0), (1.1, 0.0), (0.0, 1.1)]);
+
+        let fragments = drawcall
+            .vertices
+            .assemble(triangle.at(vi), sm::Draw::triangle_list(sm::Ccw))
+            .rasterize(sm::Accuracy::Reproducible);
+
+        fragments
+            .attachments
+            .color_iter()
+            .next::<sm::tf::Rg8Uint>()
+            .set((255_u32, 128_u32));
+    });
+
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
compute pipelines tests look like this: 
```rust
#[test]
fn basic_compute_pipeline_test() {
    let gpu = basic_test_setup().unwrap().gpu;

    assert_eq!(
        [1.0; 64],
        init_array_via_gpu_compute(gpu, [1, 1], [8, 8], |dispatch, arr| {
            arr.at(dispatch.workgroup.thread_id).set(1.0);
        })
    );
}
```

render pipeline tests look like this:
```rust
#[test]
fn basic_render_pipeline_test() {
    let gpu = basic_test_setup().unwrap().gpu;

    let expected = TestImage2D::<sm::tf::Rg8Uint, 8, 8>::try_from_str(
        "
            R                G
            ░░░░░░░░▓▓░░░░░░ ░░░░░░░░▒▒░░░░░░
            ░░░░░░░░▓▓▓▓░░░░ ░░░░░░░░▒▒▒▒░░░░
            ░░░░░░░░▓▓▓▓▓▓░░ ░░░░░░░░▒▒▒▒▒▒░░
            ░░░░░░░░▓▓▓▓▓▓▓▓ ░░░░░░░░▒▒▒▒▒▒▒▒
            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
            ░░░░░░░░░░░░░░░░ ░░░░░░░░░░░░░░░░
        ",
    )
    .unwrap();

    let actual = TestImage2D::render_on_gpu(&gpu, /*indices*/ 0..3, /*instances*/ 0..1, |drawcall| {
        let vi = drawcall.vertices.index;
        let triangle = sm::Array::new([(0.0, 0.0), (1.1, 0.0), (0.0, 1.1)]);

        let fragments = drawcall.vertices
            .assemble(triangle.at(vi), sm::Draw::triangle_list(sm::Ccw))
            .rasterize(sm::Accuracy::Reproducible);

        fragments.attachments.color_iter()
            .next::<sm::tf::Rg8Uint>().set((255_u32, 128_u32));
    });

    assert_eq!(expected, actual);
}
```
