### PR TITLE
improved error-scope future behavior

### DIFF
--- a/examples/api_showcase/src/main.rs
+++ b/examples/api_showcase/src/main.rs
@@ -503,10 +503,10 @@ impl sm::CpuLayout for Mat4 {
 // // declare your own trait with a `layout()` function like this
 // // This function will be used by the `derive(GpuLayout)` proc macro
 // pub trait MyCpuLayoutTrait {
-//     fn layout() -> shame::TypeLayout;
+//     fn cpu_layout() -> shame::TypeLayout;
 // }
 
 // // tell `shame` about the layout semantics of `glam` types
 // impl MyCpuLayoutTrait for glam::Mat4 {
-//     fn layout() -> shame::TypeLayout { sm::f32x4x4::layout() }
+//     fn cpu_layout() -> shame::TypeLayout { sm::f32x4x4::gpu_layout() }
 // }

--- a/examples/shame_wgpu/src/bind_group.rs
+++ b/examples/shame_wgpu/src/bind_group.rs
@@ -51,7 +51,7 @@ macro_rules! bind_group {
         }
 
         $crate::__reexport::concat_idents! {TResources = $Struct, Resources {
-            pub struct TResources<'a> {
+            $vis struct TResources<'a> {
                 $(pub $field: <$field_ty as $crate::binding::AsBindingResource>::BindingResource<'a>),*
             }
 

--- a/examples/shame_wgpu/src/lib.rs
+++ b/examples/shame_wgpu/src/lib.rs
@@ -207,6 +207,7 @@ impl Gpu {
                 vertex_writable_storage_by_default: desc.vertex_writable_storage_by_default,
                 zero_init_workgroup_memory: desc.zero_init_workgroup_memory,
             })?,
+            call_info: call_info!(),
             surface_format: self.surface_format,
         })
     }
@@ -215,6 +216,7 @@ impl Gpu {
 pub struct PipelineEncoder<P: IsPipelineKind> {
     gpu: wgpu::Device,
     enc_guard: EncodingGuard<P>,
+    call_info: shame::__private::CallInfo,
     surface_format: Option<wgpu::TextureFormat>,
 }
 
@@ -328,7 +330,8 @@ impl PipelineEncoder<Compute> {
     /// or code generation.
     #[track_caller]
     pub fn finish(self) -> Result<wgpu::ComputePipeline, Error> {
-        let pdef = self.enc_guard.finish()?;
+        let mut pdef = self.enc_guard.finish()?;
+        pdef.label = Some(format!("@{}", self.call_info));
 
         if shame::__private::DEBUG_PRINT_ENABLED {
             //println!("code spans:\n{:?}", pdef.shader.code);
@@ -347,7 +350,8 @@ impl PipelineEncoder<Render> {
     /// or code generation.
     #[track_caller]
     pub fn finish(self) -> Result<wgpu::RenderPipeline, Error> {
-        let pdef = self.enc_guard.finish()?;
+        let mut pdef = self.enc_guard.finish()?;
+        pdef.label = Some(format!("{}", self.call_info));
 
         if shame::__private::DEBUG_PRINT_ENABLED {
             //println!("code spans:\n{:?}", pdef.shader.code);

--- a/shame/Cargo.toml
+++ b/shame/Cargo.toml
@@ -31,3 +31,4 @@ shame_wgpu = { path = "../examples/shame_wgpu" }
 bytemuck = { version = "1.19", features = ["derive"] }
 wgpu = "25.0.2"
 pollster = "0.4"
+futures = "0.3.31"

--- a/shame/src/frontend/encoding/features.rs
+++ b/shame/src/frontend/encoding/features.rs
@@ -275,7 +275,7 @@ pub struct WorkGroup<Dim: GridDim> {
     pub thread_grid_size: vec<u32, Dim>, // user defined [u32; N] fed into sm::vec::new
     /// the 1-dimensional numeric index of a thread within its workgroup.
     ///
-    /// It lies in the range `shame::zero()..self.thread_grid_size`
+    /// It lies in the range `0..self.thread_grid_size.comp_product()`
     ///
     /// this value is different per thread
     pub thread_id: u32x1,


### PR DESCRIPTION
- `WgpuErrorScope` now has better `await` behavior.
Error scopes can be closed and opened via `next` without having to actually await the previous scope's error.

- fixed an issue where wgpu expects non-strip topologies to not supply an index format.

- other small changes 