### PR TITLE
rust 1.90.0 breaking change fix

### DIFF
--- a/examples/shame_wgpu/src/lib.rs
+++ b/examples/shame_wgpu/src/lib.rs
@@ -1,6 +1,7 @@
 //! shame wgpu integration
 //!
 //! bind-group and pipeline glue code
+#![allow(mismatched_lifetime_syntaxes)]
 pub use shame::*;
 pub mod bind_group;
 pub mod binding;

--- a/shame/src/lib.rs
+++ b/shame/src/lib.rs
@@ -3,7 +3,7 @@
 //#![warn(clippy::cast_lossless)]
 #![deny(missing_docs)]
 #![allow(clippy::match_like_matches_macro, clippy::diverging_sub_expression)]
-#![allow(unused)]
+#![allow(unused, mismatched_lifetime_syntaxes)]
 
 mod backend;
 mod common;

--- a/shame_derive/src/derive_layout.rs
+++ b/shame_derive/src/derive_layout.rs
@@ -266,7 +266,7 @@ pub fn impl_for_struct(
                             Ok(t) => t,
                             Err(actual_len) => {
                                 let any = push_wrong_amount_of_args_error(actual_len, EXPECTED_LEN, #re::call_info!());
-                                [any; EXPECTED_LEN]
+                                std::array::from_fn(|_| any)
                             }
                         };
 
@@ -533,7 +533,9 @@ pub fn impl_for_struct(
                                 Ok(t) => t,
                                 Err(actual_len) => {
                                     let any = push_wrong_amount_of_args_error(actual_len, EXPECTED_LEN, #re::call_info!());
-                                    [any; EXPECTED_LEN]
+                                    // rust 1.90.0 breaking change workaround. 
+                                    // `[any; EXPECTED_LEN]` no longer compiles
+                                    std::array::from_fn(|_| any)
                                 }
                             };
                             Self {


### PR DESCRIPTION
updating from rust 1.89 to 1.90 causes the `derive(shame::GpuLayout)` macro to no longer compile. This is a workaround.